### PR TITLE
Fix null reference risk in GetUserRewards log statement

### DIFF
--- a/Cometa.Api/Controllers/UsersController.cs
+++ b/Cometa.Api/Controllers/UsersController.cs
@@ -64,7 +64,7 @@ namespace Cometa.Api.Controllers
             try 
             {
                 // Debug output
-                Console.WriteLine("GetUserRewards called. User authenticated: " + User.Identity.IsAuthenticated);
+                Console.WriteLine("GetUserRewards called. User authenticated: " + User.Identity?.IsAuthenticated);
         
                 // Get user ID from the authenticated user
                 var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);


### PR DESCRIPTION
Updated the debug log in GetUserRewards to handle potential null references for User.Identity. This ensures the application avoids crashes if the User object is not properly initialized.