### PR TITLE
Refactor task handling to improve skill mapping and role claims

### DIFF
--- a/Cometa.Api/Controllers/AuthController.cs
+++ b/Cometa.Api/Controllers/AuthController.cs
@@ -90,7 +90,6 @@ namespace Cometa.Api.Controllers
         // JWT Token generieren
         private async Task<string> GenerateJwtTokenAsync(ApplicationUser user)
         {
-            // Basis-Claims
             var claims = new List<Claim>
             {
                 new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
@@ -98,17 +97,17 @@ namespace Cometa.Api.Controllers
                 new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
             };
 
-            // Rollen abrufen und als Claims hinzufügen
             var roles = await _userManager.GetRolesAsync(user);
-            claims.AddRange(roles.Select(role => new Claim("role", role)));
 
-            // Use the secret key from configuration, not user email
+            // ✅ Richtiger ClaimType für Rollen!
+            claims.AddRange(roles.Select(role => new Claim(ClaimTypes.Role, role)));
+
             var secretKey = _configuration["Jwt:SecretKey"];
             if (string.IsNullOrEmpty(secretKey))
             {
                 throw new InvalidOperationException("JWT SecretKey is not configured");
             }
-    
+
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secretKey));
             var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
@@ -122,6 +121,7 @@ namespace Cometa.Api.Controllers
 
             return new JwtSecurityTokenHandler().WriteToken(token);
         }
+
 
 
     }

--- a/Cometa.Api/DTOs/TaskDto.cs
+++ b/Cometa.Api/DTOs/TaskDto.cs
@@ -1,18 +1,22 @@
+using Cometa.Persistence.Enums;
 using TaskStatus = Cometa.Persistence.Enums.TaskStatus;
 
 namespace Cometa.Api.DTOs;
 
 public class TaskDto
 {
-    public Guid Id { get; set; } // Eindeutige ID, Non-Nullable
-    public required string Name { get; set; } // Name ist erforderlich
-    public string? Description { get; set; } // Optionale Beschreibung
-    public DateTime? StartDate { get; set; } // Optionales Startdatum
-    public DateTime? DueDate { get; set; }  // Optionales Fälligkeitsdatum
-    public List<string> Skills { get; set; } = new(); // Keine nullable Items in der Liste
-    public bool IsCompleted { get; set; } // Standardmäßig false
-    public int Rewards { get; set; } // Anzahl der Belohnungen
+    public Guid Id { get; set; } 
+    public required string Name { get; set; } 
+    public string? Description { get; set; } 
+    public DateTime? StartDate { get; set; } 
+    public DateTime? DueDate { get; set; }  
+    public List<string> Skills { get; set; } = new(); 
+    public List<string> SkillNames { get; set; } = new(); 
+    public bool IsCompleted { get; set; } 
+    public int Rewards { get; set; } 
     public TaskStatus Status { get; set; } = TaskStatus.Waiting;
+    public CreationStatus CreationStatus { get; set; } = CreationStatus.Draft;
     public Guid? AssigneeId { get; set; }
     public string? AssigneeName { get; set; }
+
 }

--- a/Cometa.Api/Program.cs
+++ b/Cometa.Api/Program.cs
@@ -69,7 +69,7 @@ builder.Services.AddAuthentication(options =>
             ValidIssuer = builder.Configuration["Jwt:Issuer"],
             ValidAudience = builder.Configuration["Jwt:Audience"],
             IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secretKey)),
-            RoleClaimType = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
+            RoleClaimType = ClaimTypes.Role,
         };
     });
 
@@ -124,11 +124,11 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
-
+app.UseHttpsRedirection();
 app.UseRouting();
 app.UseCors("AllowAngularApp");
 app.UseAuthentication();
 app.UseAuthorization();
+
 app.MapControllers();
-app.UseHttpsRedirection();
 app.Run();


### PR DESCRIPTION
Refactored task creation and update logic by introducing a helper method to map `SkillNames` to `TaskSkills`, improving code clarity and reusability. Adjusted DTOs to include `SkillNames` and a new `CreationStatus` attribute for better task lifecycle management. Updated role claim types to use `ClaimTypes.Role` for consistency, and streamlined comments and formatting in the affected files.