### PR TITLE
Add effort estimation fields to Tasks

### DIFF
--- a/Cometa.Api/DTOs/TaskDto.cs
+++ b/Cometa.Api/DTOs/TaskDto.cs
@@ -18,5 +18,7 @@ public class TaskDto
     public CreationStatus CreationStatus { get; set; } = CreationStatus.Draft;
     public Guid? AssigneeId { get; set; }
     public string? AssigneeName { get; set; }
+    public int? EffortMin { get; set; }
+    public int? EffortMax { get; set; }
 
 }

--- a/Cometa.Persistence/Migrations/20250331050146_AddTaskEffortEstimation.Designer.cs
+++ b/Cometa.Persistence/Migrations/20250331050146_AddTaskEffortEstimation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Cometa.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Cometa.Persistence.Migrations
 {
     [DbContext(typeof(CometaDbContext))]
-    partial class CometaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250331050146_AddTaskEffortEstimation")]
+    partial class AddTaskEffortEstimation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Cometa.Persistence/Migrations/20250331050146_AddTaskEffortEstimation.cs
+++ b/Cometa.Persistence/Migrations/20250331050146_AddTaskEffortEstimation.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Cometa.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTaskEffortEstimation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "EffortMax",
+                table: "Tasks",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EffortMin",
+                table: "Tasks",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EffortMax",
+                table: "Tasks");
+
+            migrationBuilder.DropColumn(
+                name: "EffortMin",
+                table: "Tasks");
+        }
+    }
+}

--- a/Cometa.Persistence/Model/TaskEntity.cs
+++ b/Cometa.Persistence/Model/TaskEntity.cs
@@ -77,4 +77,11 @@ public class TaskEntity : BaseEntity
     [MaxLength(100)]
     public Guid? AssigneeId { get; set; }
     public ApplicationUser? Assignee { get; set; }
+    
+    [Range(0, int.MaxValue)]
+    public int? EffortMin { get; set; }
+    
+    [Range(0, int.MaxValue)]
+    public int? EffortMax { get; set; }
+    
 }


### PR DESCRIPTION
Introduced `EffortMin` and `EffortMax` fields to the Task entity, DTO, and database schema for effort estimation. Updated the TasksController to handle these fields, including validation to ensure `EffortMin` does not exceed `EffortMax`.